### PR TITLE
Make minor UX fixes

### DIFF
--- a/httpdocs/assets/css/style.css
+++ b/httpdocs/assets/css/style.css
@@ -309,3 +309,11 @@ pre {
     color: black !important;
   }
 }
+
+.mt-5 {
+    margin-top: 6rem !important;
+}
+
+.row > * {
+    padding-left: calc(var(--bs-gutter-x) * 1.0);
+}

--- a/src/App/templates/app/community.phtml
+++ b/src/App/templates/app/community.phtml
@@ -35,7 +35,7 @@
                         <p class="card-text">
                             Join discussions, ask questions, and share your ideas with the community.
                         </p>
-                        <a href="https://github.com/php-db/discussions" class="btn btn-outline-light">
+                        <a href="https://github.com/php-db/discussions" class="btn btn-secondary">
                             Join Discussion
                         </a>
                     </div>


### PR DESCRIPTION
This change adds even spacing on either side of the timeline separator under "**Our Story**" on the About page, and an even amount of spacing above the page H1 header. I noticed these little things while looking at the site locally (running Linux). Otherwise, it seems more or less fine.